### PR TITLE
Improve README with training data example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,19 @@ framework and PyTorch.
 3. Gather training data in JSON format. Each sample should contain a
    `features` list (game state values) and an `actions` list (controller
    outputs). See `ml_bot/train.py` for details.
+   The data should look like:
+
+   ```json
+   [
+     {"features": [0.0, 1.2, ...], "actions": [0.5, -1.0, ...]},
+     ...
+   ]
+   ```
 4. Train the model:
 
    ```bash
+   # Run this command from the repository root so the ml_bot package resolves
+   # correctly.
    python -m ml_bot.train path/to/training_data.json --epochs 20
    ```
 


### PR DESCRIPTION
## Summary
- illustrate expected JSON structure for training data in README
- advise running the training command from the repo root

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845a7b2d728833182427563b0fb1834