### PR TITLE
Add pyproject config and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ scratch.
    - Python 3.8 or newer.
    - Rocket League (the game must be installed to run RLBot).
 
-2. **Install Python dependencies**
+2. **Install the package**
 
-   All required packages are listed in `requirements.txt` and include
-   `rlbot`, `numpy` and `torch`.
+   Install this project in editable mode to pull in dependencies and
+   register the ``bot-maker`` command.
 
    ```bash
-   pip install -r requirements.txt
+   pip install -e .
    ```
 
 3. **Gather training data**
@@ -38,9 +38,8 @@ scratch.
 4. **Train the model**
 
    ```bash
-   # Run this command from the repository root so the ml_bot package resolves
-   # correctly.
-   python -m ml_bot.train path/to/training_data.json --epochs 20
+   # Run this command from the repository root so the package resolves correctly.
+   bot-maker path/to/training_data.json --epochs 20
    ```
 
 5. **Create `rlbot.cfg`**

--- a/ml_bot/train.py
+++ b/ml_bot/train.py
@@ -57,11 +57,24 @@ def train(data_path: str, epochs: int = 10, batch_size: int = 64):
     print(f"Model saved to {model_path}")
 
 
-if __name__ == "__main__":
+def main(argv=None):
+    """Entry point for the ``bot-maker`` command."""
     import argparse
 
     parser = argparse.ArgumentParser(description="Train Rocket League bot model")
-    parser.add_argument("data", help="Path to JSON file containing training data")
-    parser.add_argument("--epochs", type=int, default=10, help="Number of epochs")
-    args = parser.parse_args()
+    parser.add_argument(
+        "data",
+        help="Path to JSON file containing training data",
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=10,
+        help="Number of epochs",
+    )
+    args = parser.parse_args(argv)
     train(args.data, args.epochs)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "rl-bot-trin"
+version = "0.1.0"
+description = "Example RLBot ML bot using PyTorch"
+authors = [{name = "Unknown"}]
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "rlbot>=1.35",
+    "numpy",
+    "torch",
+]
+
+[project.scripts]
+bot-maker = "ml_bot.train:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["ml_bot*"]


### PR DESCRIPTION
## Summary
- add `pyproject.toml` packaging metadata
- expose `bot-maker` console script
- document editable install
- update training instructions to use the new command
- create a `main` entry point in training script

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -e .` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_6845abbe9c5883319505cc0ebe6eb30b