### PR TITLE
Add bot_maker CLI module

### DIFF
--- a/bot_maker/__main__.py
+++ b/bot_maker/__main__.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+BOT_TEMPLATE = """from rlbot.agents.base_agent import BaseAgent, SimpleControllerState
+
+class Bot(BaseAgent):
+    def get_output(self, packet) -> SimpleControllerState:
+        return SimpleControllerState()
+"""
+
+CFG_TEMPLATE = """[PYTHON_BOT]
+python_file = bot.py
+class = Bot
+"""
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog="bot-maker")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    new_parser = subparsers.add_parser("new", help="Create a new bot project")
+    new_parser.add_argument("name")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "new":
+        target = Path(args.name)
+        target.mkdir(parents=True, exist_ok=True)
+        (target / "bot.py").write_text(BOT_TEMPLATE)
+        (target / "rlbot.cfg").write_text(CFG_TEMPLATE)
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,10 @@ dependencies = [
     "torch",
 ]
 
+
 [project.scripts]
-bot-maker = "ml_bot.train:main"
+bot-maker = "bot_maker.__main__:main"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["ml_bot*"]
+include = ["ml_bot*", "bot_maker*"]

--- a/tests/test_bot_maker.py
+++ b/tests/test_bot_maker.py
@@ -1,13 +1,17 @@
 import subprocess
 import sys
 from pathlib import Path
+import os
 
 
 def test_bot_maker_creates_files(tmp_path):
     temp_dir = tmp_path
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
     result = subprocess.run(
         [sys.executable, "-m", "bot_maker", "new", "temp_bot"],
         cwd=temp_dir,
+        env=env,
         capture_output=True,
         text=True,
     )


### PR DESCRIPTION
## Summary
- introduce `bot_maker` package with `__main__.py`
- implement minimal `bot-maker new` command that scaffolds `bot.py` and `rlbot.cfg`
- expose new CLI entrypoint via `pyproject.toml`
- update tests to add PYTHONPATH so the module can be executed from a temp folder

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ae47bf04833194c21bc964cad72e