### PR TITLE
Update pyproject scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,9 @@ dependencies = [
 ]
 
 [project.scripts]
-bot-maker = "ml_bot.train:main"
+bot-maker = "bot_maker.__main__:main"
+ml-bot-train = "ml_bot.train:main"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["ml_bot*"]
+include = ["ml_bot*", "bot_maker*"]


### PR DESCRIPTION
## Summary
- register `bot-maker` console entry point
- add optional `ml-bot-train` script
- include `bot_maker` in package discovery

## Testing
- `pytest -q` *(fails: No module named bot_maker)*

------
https://chatgpt.com/codex/tasks/task_e_6845ae4900088331b7395daf3c7f5d49