### PR TITLE
Add bot maker usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ and negative rewards, use shaping effectively, and lists useful `GameTickPacket`
 ## Bot Maker
 
 RLBot ships with a `bot-maker` command that can scaffold a new bot project.
-See [docs/bot_maker.md](docs/bot_maker.md) for a full guide. To create a bot
+See the [Bot Maker guide](docs/bot_maker.md) for detailed usage notes. To create a bot
 named `MyBot` run:
 
 ```bash

--- a/docs/bot_maker.md
+++ b/docs/bot_maker.md
@@ -1,8 +1,6 @@
 # Bot Maker Guide
 
-The RLBot package provides a `bot-maker` command-line tool which can generate
-a new bot project for you. Installing RLBot will place the script in your PATH
-along with the standard RLBot modules.
+The RLBot package provides a `bot-maker` command-line tool which can generate a new bot project for you. Installing RLBot will place the script in your PATH along with the standard RLBot modules.
 
 ## Installation
 
@@ -22,9 +20,18 @@ Run `bot-maker new` followed by the name of your bot:
 bot-maker new MyAwesomeBot
 ```
 
-The command will create a new folder named `MyAwesomeBot` with example
-configuration files and a starter Python bot. You can then open the folder and
-begin customizing the code.
+The command will create a new folder named `MyAwesomeBot` with example configuration files and a starter Python bot. You can then open the folder and begin customizing the code.
 
-See the RLBot documentation for more details on the generated files and
-additional `bot-maker` options.
+## Using the Generated Project
+
+Within the new folder you'll find:
+
+- `bot.py` – a minimal bot implementation.
+- `rlbot.cfg` – configuration to register the bot with RLBot.
+- Example loadout and team settings.
+
+Open `bot.py` to start editing your bot's behavior. Launch a match using the RLBot GUI or the `rlbot-run` command to test changes immediately.
+
+Pass `--help` to `bot-maker` for a list of additional options, including template choices and folder paths.
+
+See the RLBot documentation for more details on the generated files and other `bot-maker` features.


### PR DESCRIPTION
## Summary
- expand the RLBot bot-maker guide with usage notes
- point to the bot maker guide from README

## Testing
- `pytest -q` *(fails: No module named bot_maker)*

------
https://chatgpt.com/codex/tasks/task_e_6845ae4b0f248331abfb55491d151459