### PR TITLE
Fix training docstring

### DIFF
--- a/ml_bot/train.py
+++ b/ml_bot/train.py
@@ -58,7 +58,7 @@ def train(data_path: str, epochs: int = 10, batch_size: int = 64):
 
 
 def main(argv=None):
-    """Entry point for the ``bot-maker`` command."""
+    """Entry point for the ``ml-bot-train`` script."""
     import argparse
 
     parser = argparse.ArgumentParser(description="Train Rocket League bot model")


### PR DESCRIPTION
## Summary
- clarify that `main()` is used by the `ml-bot-train` script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845b2e1f1708331b0af2b1be04a8ef4