### PR TITLE
Fix CLI for Python 3.8

### DIFF
--- a/bot_maker/__main__.py
+++ b/bot_maker/__main__.py
@@ -1,7 +1,6 @@
-from __future__ import annotations
-
 import argparse
 from pathlib import Path
+from typing import List, Optional
 
 BOT_TEMPLATE = """from rlbot.agents.base_agent import BaseAgent, SimpleControllerState
 
@@ -15,7 +14,7 @@ python_file = bot.py
 class = Bot
 """
 
-def main(argv: list[str] | None = None) -> None:
+def main(argv: Optional[List[str]] = None) -> None:
     parser = argparse.ArgumentParser(prog="bot-maker")
     subparsers = parser.add_subparsers(dest="command", required=True)
 


### PR DESCRIPTION
## Summary
- remove Python 3.10 style union type from `bot_maker.__main__`
- add `typing` imports for Optional and List

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845b6cca73c833180319202bf85e8a6