### PR TITLE
Fix GameTickPacket import

### DIFF
--- a/ml_bot/bot.py
+++ b/ml_bot/bot.py
@@ -3,7 +3,7 @@ from typing import Optional
 import os
 import torch
 from rlbot.agents.base_agent import BaseAgent, SimpleControllerState
-from rlbot.utils.game_state_util import GameTickPacket
+from rlbot.utils.structures.game_data_struct import GameTickPacket
 
 from .model import RocketLeagueNet
 


### PR DESCRIPTION
## Summary
- use `GameTickPacket` from `rlbot.utils.structures.game_data_struct` in ml_bot

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845c24e63548331bd03b05c6e17754c